### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/gh_docker.yml
+++ b/.github/workflows/gh_docker.yml
@@ -10,7 +10,7 @@ jobs:
         id: get_version
         run: echo ::set-output name=VERSION::$(node -e "console.log(require('./package.json').version)")        
       - name: Publish
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: fonoster/rox
           username: ${{ secrets.DOCKER_HUB_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore